### PR TITLE
Moving to larger instance type due to cpu & memory constraints

### DIFF
--- a/nessus-manager-deployment.yml
+++ b/nessus-manager-deployment.yml
@@ -27,7 +27,7 @@ instance_groups:
   - name: nessus-manager
     static_ips:
     - ((terraform_outputs.nessus_static_ip))
-  vm_type: t3.medium.nessus.manager
+  vm_type: m6i.large.nessus.manager
   vm_extensions: [nessus-manager-lb]
   persistent_disk_type: nessus-manager
   stemcell: default


### PR DESCRIPTION
## Changes proposed in this pull request:
- Nessus manager is using a burstable T class and running into CPU and memory constraints to moving to a larger/stable instance class

## security considerations
n/a